### PR TITLE
Make FlexiLogger struct and methods publicly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,14 +222,14 @@ fn get_next_rotate_idx(s_filename_base: & String, o_suffix: & Option<String>) ->
 }
 
 
-struct FlexiLogger{
+pub struct FlexiLogger{
     directives: Vec<LogDirective>,
     o_filter: Option<Regex>,
     amo_line_writer: Arc<Mutex<RefCell<LwHandle>>>,
     config: LogConfig
 }
 impl FlexiLogger {
-    fn new(loglevelspec: Option<String>, config: LogConfig)
+    pub fn new(loglevelspec: Option<String>, config: LogConfig)
             -> Result<FlexiLogger, FlexiLoggerError>  {
 
         let (mut directives, filter) = match loglevelspec {
@@ -261,7 +261,7 @@ impl FlexiLogger {
         }
     }
 
-    fn fl_enabled(&self, level: LogLevel, target: &str) -> bool {
+    pub fn fl_enabled(&self, level: LogLevel, target: &str) -> bool {
         // Search for the longest match, the vector is assumed to be pre-sorted.
         for directive in self.directives.iter().rev() {
             match directive.name {


### PR DESCRIPTION
I have a use case that requires more than one FlexiLogger instance in a single process.  I have my own Log impl that tees certain log levels to one file, and other log levels to another file, and mirrors Error/Warn to stderr.  In order to have multiple FlexiLogger instances and pass a LogRecord down to it, it needs to be publicly constructable.

I don't see the harm in making it public, and allowing people to construct manually for use cases such as above, rather than forcing them to use init() and make it the one and only logger for the process.