### PR TITLE
Added explanation of size unit used by rotate_over_size and o_rotate_…

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -410,6 +410,9 @@ impl Logger {
     /// Also the filename pattern changes - instead of the timestamp,
     /// a serial number is included into the filename.
     ///
+    /// The size is given in bytes, e.g. `rotate_over_size(1_000)` will rotate
+    /// files once they reach a size of 1 kB.
+    ///
     /// This option only has an effect if `log_to_file()` is used, too.
     pub fn rotate_over_size(mut self, rotate_over_size: usize) -> Logger {
         self.flwb = self
@@ -516,6 +519,9 @@ impl Logger {
     /// the file will be closed and a new file will be opened.
     /// Also the filename pattern changes - instead of the timestamp a serial number
     /// is included into the filename.
+    ///
+    /// The size is given in bytes, e.g. `o_rotate_over_size(1_000)` will rotate
+    /// files once they reach a size of 1 kB.
     pub fn o_rotate_over_size(mut self, rotate_over_size: Option<usize>) -> Logger {
         self.flwb = self
             .flwb

--- a/src/writers/file_log_writer.rs
+++ b/src/writers/file_log_writer.rs
@@ -114,6 +114,9 @@ impl FileLogWriterBuilder {
     /// the file will be closed and a new file will be opened.
     /// Also the filename pattern changes - instead of the timestamp,
     /// a serial number is included into the filename.
+    ///
+    /// The size is given in bytes, e.g. `rotate_over_size(1_000)` will rotate
+    /// files once they reach a size of 1 kB.
     pub fn rotate_over_size(mut self, rotate_over_size: usize) -> FileLogWriterBuilder {
         self.config.rotate_over_size = Some(rotate_over_size as u64);
         self.config.use_timestamp = false;
@@ -190,6 +193,9 @@ impl FileLogWriterBuilder {
     /// the file will be closed and a new file will be opened.
     /// Also the filename pattern changes - instead of the timestamp a serial number
     /// is included into the filename.
+    ///
+    /// The size is given in bytes, e.g. `o_rotate_over_size(1_000)` will rotate
+    /// files once they reach a size of 1 kB.
     pub fn o_rotate_over_size(mut self, rotate_over_size: Option<usize>) -> FileLogWriterBuilder {
         self.config.rotate_over_size = rotate_over_size.map(|r| r as u64);
         self.config.use_timestamp = false;


### PR DESCRIPTION
…over_size to docs.

I had to dig through the code to figure this out, so thought it'd be a good idea to add it to the docs. Maybe it's obvious to most that this would be specified in bytes, but it doesn't hurt to have it in there.