### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ libc = {version = "^0.2.50", optional = true}
 
 [dev-dependencies]
 serde_derive = "1.0"
-version-sync = "0.7"
+version-sync = "0.8"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.