### PR TITLE
use Local:now() as get_creation_date() on linux

### DIFF
--- a/src/writers/file_log_writer.rs
+++ b/src/writers/file_log_writer.rs
@@ -709,12 +709,12 @@ fn rotate_output_file_to_idx(
 }
 
 // See documentation of Criterion::Age.
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn get_creation_date(_path: &PathBuf) -> Result<DateTime<Local>, FlexiLoggerError> {
     Ok(Local::now())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 fn get_creation_date(_path: &PathBuf) -> Result<DateTime<Local>, FlexiLoggerError> {
     Ok(std::fs::metadata(_path)?.created()?.into())
 }


### PR DESCRIPTION
std::fs::metadata.created() returns Err on linux (see here: https://github.com/rust-lang/rust/blob/4b9d80325a65b0375eea526409a0f3aaf1cbc23c/src/libstd/sys/unix/fs.rs#L154 ), therefore trying to log to a file currently does not work at all on Linux.

This commit uses Local::now(), which is used on Windows already and which works just fine on Linux as well, as far as I can tell.

btw, thanks for the lib, seems nice other than this bug! :+1: 