### PR TITLE
 Pass format option into custom loggers

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -486,8 +486,9 @@ impl Logger {
                     vec![Box::new(self.flwb.try_build()?)],
                 )
             }
-            LogTarget::Writer(w) => {
+            LogTarget::Writer(mut w) => {
                 self.flwb = self.flwb.format(self.format_for_file);
+                w.format(self.format_for_file);
                 PrimaryWriter::multi(self.duplicate, self.format_for_stderr, vec![w])
             }
             LogTarget::FileAndWriter(w) => {

--- a/src/writers/log_writer.rs
+++ b/src/writers/log_writer.rs
@@ -1,4 +1,5 @@
 use crate::deferred_now::DeferredNow;
+use crate::FormatFunction;
 use log::Record;
 use std::io;
 
@@ -14,6 +15,14 @@ pub trait LogWriter: Sync + Send {
 
     /// Provides the maximum log level that is to be written.
     fn max_log_level(&self) -> log::LevelFilter;
+
+    /// Sets the format function. Defaults to ([formats::default_format](fn.default_format.html)),
+    /// but can be changed with a call to [`Logger::format()`](struct.Logger.html#method.format).
+    ///
+    /// The default implementation is a no-op.
+    fn format(&mut self, format: FormatFunction) {
+        let _ = format;
+    }
 
     /// Takes a vec with three patterns per line that represent the log out,
     /// compares the written log with the expected lines,

--- a/tests/test_custom_log_writer.rs
+++ b/tests/test_custom_log_writer.rs
@@ -1,0 +1,62 @@
+use std::sync::Mutex;
+
+use flexi_logger::writers::LogWriter;
+use flexi_logger::{default_format, DeferredNow, LogTarget, Logger};
+use log::*;
+
+pub struct CustomWriter {
+    data: Mutex<Vec<u8>>,
+}
+
+impl LogWriter for CustomWriter {
+    fn write(&self, now: &mut DeferredNow, record: &Record) -> std::io::Result<()> {
+        let mut data = self.data.lock().unwrap();
+        default_format(&mut *data, now, record)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn max_log_level(&self) -> log::LevelFilter {
+        log::LevelFilter::Trace
+    }
+
+    fn validate_logs(&self, expected: &[(&'static str, &'static str, &'static str)]) {
+        let data = self.data.lock().unwrap();
+        let expected_data =
+            expected
+                .iter()
+                .fold(Vec::new(), |mut acc, (level, module, message)| {
+                    acc.extend(format!("{} [{}] {}", level, module, message).bytes());
+                    acc
+                });
+        assert_eq!(*data, expected_data);
+    }
+}
+
+#[test]
+fn test_custom_log_writer() {
+    let handle = Logger::with_str("info")
+        .log_target(LogTarget::Writer(Box::new(CustomWriter {
+            data: Mutex::new(Vec::new()),
+        })))
+        .start()
+        .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));
+
+    error!("This is an error message");
+    warn!("This is a warning");
+    info!("This is an info message");
+    debug!("This is a debug message - you must not see it!");
+    trace!("This is a trace message - you must not see it!");
+
+    handle.validate_logs(&[
+        (
+            "ERROR",
+            "test_custom_log_writer",
+            "This is an error message",
+        ),
+        ("WARN", "test_custom_log_writer", "This is a warning"),
+        ("INFO", "test_custom_log_writer", "This is an info message"),
+    ]);
+}

--- a/tests/test_custom_log_writer_format.rs
+++ b/tests/test_custom_log_writer_format.rs
@@ -1,0 +1,78 @@
+use std::sync::Mutex;
+
+use flexi_logger::writers::LogWriter;
+use flexi_logger::{default_format, DeferredNow, FormatFunction, LogTarget, Logger};
+use log::*;
+
+pub struct CustomWriter {
+    data: Mutex<Vec<u8>>,
+    format: FormatFunction,
+}
+
+impl LogWriter for CustomWriter {
+    fn write(&self, now: &mut DeferredNow, record: &Record) -> std::io::Result<()> {
+        let mut data = self.data.lock().unwrap();
+        (self.format)(&mut *data, now, record)
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn format(&mut self, format: FormatFunction) {
+        self.format = format;
+    }
+
+    fn max_log_level(&self) -> log::LevelFilter {
+        log::LevelFilter::Trace
+    }
+
+    fn validate_logs(&self, expected: &[(&'static str, &'static str, &'static str)]) {
+        let data = self.data.lock().unwrap();
+        let expected_data =
+            expected
+                .iter()
+                .fold(Vec::new(), |mut acc, (level, _module, message)| {
+                    acc.extend(format!("{}: {}", level, message).bytes());
+                    acc
+                });
+        assert_eq!(*data, expected_data);
+    }
+}
+
+fn custom_format(
+    writer: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    // Only write the message and the level, without the module
+    write!(writer, "{}: {}", record.level(), &record.args())
+}
+
+#[test]
+fn test_custom_log_writer_custom_format() {
+    let handle = Logger::with_str("info")
+        .log_target(LogTarget::Writer(Box::new(CustomWriter {
+            data: Mutex::new(Vec::new()),
+            format: default_format,
+        })))
+        .format(custom_format)
+        .start()
+        .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));
+
+    error!("This is an error message");
+    warn!("This is a warning");
+    info!("This is an info message");
+    debug!("This is a debug message - you must not see it!");
+    trace!("This is a trace message - you must not see it!");
+
+    handle.validate_logs(&[
+        (
+            "ERROR",
+            "test_custom_log_writer",
+            "This is an error message",
+        ),
+        ("WARN", "test_custom_log_writer", "This is a warning"),
+        ("INFO", "test_custom_log_writer", "This is an info message"),
+    ]);
+}


### PR DESCRIPTION
Custom loggers can now make use of a formatting function supplied by the
`format()` call when creating the logger instance.