### PR TITLE
Make textfilter optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,12 @@ categories = ["development-tools::debugging"]
 all-features = true
 
 [features]
-default = ["colors"]
+default = ["colors", "textfilter"]
 colors = ["yansi"]
 specfile = ["serde","toml","notify", "serde_derive"]
 syslog_writer = ["libc", "hostname"]
 ziplogs = ["flate2"]
+textfilter = ["regex"]
 
 [dependencies]
 chrono = "0.4"
@@ -32,7 +33,7 @@ glob = "0.3"
 hostname = {version = "0.3", optional = true}
 log = { version = "0.4", features = ["std"] }
 notify = { version = "4.0", optional = true }
-regex = "1.1"
+regex = { version = "1.1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = {version = "1.0", optional = true}
 thiserror = "1.0"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ or all rotated log files in zipped form rather than as text files.
 
 This is still an experimental feature, likely working, but not well tested. Feedback of all kinds is highly appreciated.
 
+### **`textfilter`**
+
+Removes the ability to filter logs by text, but also removes the dependency on the regex crate.
+
 ## Versions
 
 See the [change log](https://github.com/emabee/flexi_logger/blob/master/CHANGELOG.md).

--- a/src/flexi_logger.rs
+++ b/src/flexi_logger.rs
@@ -3,6 +3,7 @@ use crate::writers::LogWriter;
 use crate::LogSpecification;
 
 use log;
+#[cfg(feature = "textfilter")]
 use regex::Regex;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -115,18 +116,21 @@ impl log::Log for FlexiLogger {
         }
 
         // closure that we need below
-        let check_text_filter = |text_filter: &Option<Regex>| {
-            if let Some(filter) = text_filter.as_ref() {
-                filter.is_match(&*record.args().to_string())
-            } else {
-                true
-            }
-        };
+        #[cfg(feature = "textfilter")]
+        {
+            let check_text_filter = |text_filter: &Option<Regex>| {
+                if let Some(filter) = text_filter.as_ref() {
+                    filter.is_match(&*record.args().to_string())
+                } else {
+                    true
+                }
+            };
 
-        if !check_text_filter(
-            self.log_specification.read().as_ref().unwrap(/* expose this? */).text_filter(),
-        ) {
-            return;
+            if !check_text_filter(
+                self.log_specification.read().as_ref().unwrap(/* expose this? */).text_filter(),
+            ) {
+                return;
+            }
         }
 
         self.primary_writer

--- a/tests/test_parse_errors.rs
+++ b/tests/test_parse_errors.rs
@@ -14,6 +14,7 @@ fn parse_errors_logspec() {
                     .unwrap()
                     .module_filters()
             );
+            #[cfg(feature = "textfilter")]
             assert!(logspec.text_filter().is_none());
         }
         _ => panic!("Wrong error from parsing (1)"),
@@ -28,6 +29,7 @@ fn parse_errors_logspec() {
                 logspec.module_filters(),
                 LogSpecification::parse("info").unwrap().module_filters()
             );
+            #[cfg(feature = "textfilter")]
             assert!(logspec.text_filter().is_none());
         }
         _ => panic!("Wrong error from parsing (2)"),
@@ -39,6 +41,7 @@ fn parse_errors_logspec() {
                 logspec.module_filters(),
                 LogSpecification::off().module_filters()
             );
+            #[cfg(feature = "textfilter")]
             assert!(logspec.text_filter().is_none());
         }
         _ => panic!("Wrong error from parsing (3)"),
@@ -53,6 +56,7 @@ fn parse_errors_logspec() {
                 logspec.module_filters(),
                 LogSpecification::off().module_filters()
             );
+            #[cfg(feature = "textfilter")]
             assert!(logspec.text_filter().is_none());
         }
         _ => panic!("Wrong error from parsing (4)"),

--- a/tests/test_textfilter.rs
+++ b/tests/test_textfilter.rs
@@ -1,13 +1,14 @@
-use flexi_logger::{default_format, LogSpecification, Logger};
-use log::*;
-
-use std::env;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
-
 #[test]
+#[cfg(feature = "textfilter")]
 fn test_textfilter() {
+    use flexi_logger::{default_format, LogSpecification, Logger};
+    use log::*;
+
+    use std::env;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+    use std::path::Path;
+
     let logspec = LogSpecification::parse("info/Hello").unwrap();
     Logger::with(logspec)
         .format(default_format)


### PR DESCRIPTION
Having a textfilter requires the regex crate, which adds significant
size overhead for any binary using flexi_logger. In environments
where space is limited, this might be undersirable. This commit
makes textfilter optional and removes the regex crate as a required
dependency.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>