### PR TITLE
Check for all whitespaces

### DIFF
--- a/src/log_specification.rs
+++ b/src/log_specification.rs
@@ -407,7 +407,7 @@ fn parse_level_filter<S: AsRef<str>>(s: S) -> Result<LevelFilter, FlexiLoggerErr
 }
 
 fn contains_whitespace(s: &str, parse_errs: &mut String) -> bool {
-    let result = s.find(' ').is_some() || s.find('\t').is_some();
+    let result = s.chars().any(|c| c.is_whitespace());
     if result {
         push_err(
             &format!(

--- a/src/log_specification.rs
+++ b/src/log_specification.rs
@@ -411,7 +411,7 @@ fn contains_whitespace(s: &str, parse_errs: &mut String) -> bool {
     if result {
         push_err(
             &format!(
-                "ignoring invalid part in log spec '{}' (contains a dash or whitespace)",
+                "ignoring invalid part in log spec '{}' (contains a whitespace)",
                 s
             ),
             parse_errs,


### PR DESCRIPTION
Minor tweak to catch all whitespaces instead of limiting ourselves to spaces (`' '`) and tabs (`'\t'`).

This makes the code more international ! :D

See [`is_whitespace`](https://doc.rust-lang.org/std/primitive.char.html#method.is_whitespace) for the exact definition of what is a whitespace :)