### PR TITLE
Add log rotation and detailed formatting examples

### DIFF
--- a/examples/detailed_log_format.rs
+++ b/examples/detailed_log_format.rs
@@ -1,0 +1,18 @@
+use flexi_logger::{detailed_format, Logger};
+use log::{debug, error, info, trace, warn};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Logger::with_str("info").format(detailed_format).start()?;
+
+    error!("This is an error message");
+    warn!("This is a warning");
+    info!("This is an info message");
+    debug!("This is a debug message - you must not see it!");
+    trace!("This is a trace message - you must not see it!");
+
+    // example log entry:
+    // [2020-10-04 10:19:55.966101 +02:00] ERROR [detailed_log_format] examples/detailed_log_format.rs:8: This is an error message
+
+    Ok(())
+}

--- a/examples/rotation.rs
+++ b/examples/rotation.rs
@@ -1,0 +1,24 @@
+use flexi_logger::{Age, Cleanup, Criterion, Logger, Naming};
+use log::{debug, error, info, trace, warn};
+use std::env;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Logger::with_str("info")
+        .directory(env::temp_dir())
+        .log_to_file()
+        .rotate(
+            Criterion::Age(Age::Day), // Every day new log file is created.
+            Naming::Timestamps,       // Each file has timestamp in it's name.
+            Cleanup::KeepLogFiles(3), // Keep max of 3 log files.
+        )
+        .start()?;
+
+    error!("This is an error message");
+    warn!("This is a warning");
+    info!("This is an info message");
+    debug!("This is a debug message - you must not see it!");
+    trace!("This is a trace message - you must not see it!");
+
+    Ok(())
+}


### PR DESCRIPTION
Hello. First of all thank you for sharing your work, I really appreciate that. 

In this PR I'm adding two examples:
1. Log rotation usage.
2. Detailed formatting.

When I was working with your library it took me more time that I would expect to get the idea how to configure log rotation with detailed formatting, that's why I created this PR. 

When writing the code I realized that I could easily get the idea how to configure the logger by looking on the code in `tests` dir, however I think it will be easier for people to skim through `examples` dir first and the chance of missing sample code is smaller