### PR TITLE
feat: Optional feature to de-dup consecutive logs after some leeway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ specfile_without_notification = ["serde","toml","serde_derive"]
 syslog_writer = ["libc", "hostname"]
 compress = ["flate2"]
 textfilter = ["regex"]
+dedup = []
 
 [dependencies]
 atty = {version = "0.2", optional = true}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ There are configuration options to e.g.
 * configure the path and the filenames of the log files,
 * use file rotation,
 * specify the line format for the log lines,
+* use logs deduplication (i.e. log a "last record was skipped N times"
+  message after getting the same record for X consecutive times),
 * define additional log streams, e.g for alert or security messages,
 * support changing the log specification on the fly, while the program is running,
 
@@ -122,6 +124,11 @@ See [issue-59](https://github.com/emabee/flexi_logger/issues/59) for more detail
 ### **`textfilter`**
 
 Removes the ability to filter logs by text, but also removes the dependency on the regex crate.
+
+### **`dedup`**
+
+The `dedup` feature adds the ability to skip duplicated logs after getting the
+same record for a -configurable- consecutive amount of times.
 
 ### **`syslog`**
 

--- a/benches/bench_dedup.rs
+++ b/benches/bench_dedup.rs
@@ -1,14 +1,15 @@
 #![feature(test)]
 extern crate test;
 
-use std::num::NonZeroUsize;
-
-use flexi_logger::{FileSpec, Logger};
-use test::Bencher;
-
+#[cfg(feature = "dedup")]
 #[bench]
-fn b10_dedup(b: &mut Bencher) {
-    Logger::with_str("info")
+fn b10_dedup(b: &mut test::Bencher) {
+    use std::num::NonZeroUsize;
+
+    use flexi_logger::{FileSpec, Logger};
+
+    Logger::try_with_str("info")
+        .unwrap()
         .log_to_file(FileSpec::default().directory("log_files"))
         .dedup(NonZeroUsize::new(2).unwrap())
         .start()

--- a/benches/bench_dedup.rs
+++ b/benches/bench_dedup.rs
@@ -1,0 +1,22 @@
+#![feature(test)]
+extern crate test;
+
+use std::num::NonZeroUsize;
+
+use flexi_logger::{FileSpec, Logger};
+use test::Bencher;
+
+#[bench]
+fn b10_dedup(b: &mut Bencher) {
+    Logger::with_str("info")
+        .log_to_file(FileSpec::default().directory("log_files"))
+        .dedup(NonZeroUsize::new(2).unwrap())
+        .start()
+        .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));
+
+    b.iter(|| {
+        for i in 0..100 {
+            log::info!("{}", if i != 0 && i % 5 == 0 { "bar" } else { "foo" });
+        }
+    });
+}

--- a/benches/bench_no_dedup.rs
+++ b/benches/bench_no_dedup.rs
@@ -1,0 +1,21 @@
+#![feature(test)]
+extern crate test;
+
+use std::num::NonZeroUsize;
+
+use flexi_logger::{FileSpec, Logger};
+use test::Bencher;
+
+#[bench]
+fn b10_no_dedup(b: &mut Bencher) {
+    Logger::with_str("info")
+        .log_to_file(FileSpec::default().directory("log_files"))
+        .start()
+        .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));
+
+    b.iter(|| {
+        for i in 0..100 {
+            log::info!("{}", if i != 0 && i % 5 == 0 { "bar" } else { "foo" });
+        }
+    });
+}

--- a/benches/bench_no_dedup.rs
+++ b/benches/bench_no_dedup.rs
@@ -1,14 +1,13 @@
 #![feature(test)]
 extern crate test;
 
-use std::num::NonZeroUsize;
-
 use flexi_logger::{FileSpec, Logger};
 use test::Bencher;
 
 #[bench]
 fn b10_no_dedup(b: &mut Bencher) {
-    Logger::with_str("info")
+    Logger::try_with_str("info")
+        .unwrap()
         .log_to_file(FileSpec::default().directory("log_files"))
         .start()
         .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));

--- a/examples/dedup.rs
+++ b/examples/dedup.rs
@@ -1,0 +1,20 @@
+fn main() {
+    #[cfg(not(feature = "dedup"))]
+    println!("Feature dedup is switched off");
+
+    #[cfg(feature = "dedup")]
+    {
+        flexi_logger::Logger::with_str("info")
+            .format(flexi_logger::colored_detailed_format)
+            .log_to_stdout()
+            .dedup(std::num::NonZeroUsize::new(2).unwrap())
+            .start()
+            .unwrap();
+
+        for i in 0..10 {
+            log::info!("{}", if i == 5 { "bar" } else { "foo" });
+        }
+
+        log::info!("the end");
+    }
+}

--- a/examples/dedup.rs
+++ b/examples/dedup.rs
@@ -4,7 +4,8 @@ fn main() {
 
     #[cfg(feature = "dedup")]
     {
-        flexi_logger::Logger::with_str("info")
+        flexi_logger::Logger::try_with_str("info")
+            .unwrap()
             .format(flexi_logger::colored_detailed_format)
             .log_to_stdout()
             .dedup(std::num::NonZeroUsize::new(2).unwrap())

--- a/src/deduper.rs
+++ b/src/deduper.rs
@@ -1,0 +1,238 @@
+use std::{borrow::ToOwned, cmp::Ordering, num::NonZeroUsize};
+
+use log::Record;
+
+/// A helper to track duplicated consecutive logs and skip them until a
+/// different event is received.
+pub struct Deduper {
+    leeway: NonZeroUsize,
+    last_record: LastRecord,
+    duplicates: usize,
+}
+
+/// Action to be performed for some record.
+#[derive(Debug, PartialEq)]
+pub enum DedupAction {
+    /// The record should be allowed and logged normally.
+    Allow,
+    /// The record is the last consecutive duplicate to be allowed.
+    ///
+    /// Any following duplicates will be skipped until a different event is
+    /// received (or the duplicates count overflows).
+    AllowLastOfLeeway(usize),
+    /// The record should be allowed, the last `N` records were skipped as
+    /// consecutive duplicates.
+    AllowAfterSkipped(usize),
+    /// The record should be skipped because no more consecutive duplicates
+    /// are allowed.
+    Skip,
+}
+
+impl Deduper {
+    /// Constructs a new [`Deduper`] that will skip duplicated entries after
+    /// some record has been received for the consecutive times specified by
+    /// `leeway`.
+    pub fn with_leeway(leeway: NonZeroUsize) -> Self {
+        Self {
+            leeway,
+            last_record: LastRecord {
+                file: None,
+                line: None,
+                msg: String::new(),
+            },
+            duplicates: 0,
+        }
+    }
+
+    /// Returns wether a record should be skipped or allowed.
+    ///
+    /// See [`DedupAction`].
+    pub fn dedup(&mut self, record: &Record) -> DedupAction {
+        let new_line = record.line();
+        let new_file = record.file();
+        let new_msg = record.args().to_string();
+        if new_line == self.last_record.line
+            && new_file == self.last_record.file.as_deref()
+            && new_msg == self.last_record.msg
+        {
+            // Update dups count
+            if let Some(updated_dups) = self.duplicates.checked_add(1) {
+                self.duplicates = updated_dups;
+            } else {
+                let skipped = self.duplicates - self.leeway();
+                self.duplicates = 0;
+                return DedupAction::AllowAfterSkipped(skipped);
+            }
+
+            match self.duplicates.cmp(&self.leeway()) {
+                Ordering::Less => DedupAction::Allow,
+                Ordering::Equal => DedupAction::AllowLastOfLeeway(self.leeway()),
+                Ordering::Greater => DedupAction::Skip,
+            }
+        } else {
+            // Update last record
+            self.last_record.file = new_file.map(ToOwned::to_owned);
+            self.last_record.line = new_line;
+            self.last_record.msg = new_msg;
+
+            let dups = self.duplicates;
+            self.duplicates = 0;
+
+            match dups {
+                n if n > self.leeway() => DedupAction::AllowAfterSkipped(n - self.leeway()),
+                _ => DedupAction::Allow,
+            }
+        }
+    }
+
+    fn leeway(&self) -> usize {
+        self.leeway.get()
+    }
+}
+
+struct LastRecord {
+    file: Option<String>,
+    line: Option<u32>,
+    msg: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_record_eq() {
+        let leeway = NonZeroUsize::new(1).unwrap();
+        let msg = format_args!("b");
+        let mut deduper = Deduper::with_leeway(leeway);
+        let record = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(msg)
+            .build();
+        let diff_file = Record::builder()
+            .file(Some("b"))
+            .line(Some(1))
+            .args(msg)
+            .build();
+        let diff_line = Record::builder()
+            .file(Some("b"))
+            .line(Some(2))
+            .args(msg)
+            .build();
+        let diff_msg = Record::builder()
+            .file(Some("b"))
+            .line(Some(2))
+            .args(format_args!("diff msg"))
+            .build();
+
+        // First one is allowed
+        assert_eq!(deduper.dedup(&record), DedupAction::Allow);
+        // Second one is allowed because it comes from a diff file
+        assert_eq!(deduper.dedup(&diff_file), DedupAction::Allow);
+        // Third one is allowed because it comes from a diff line
+        assert_eq!(deduper.dedup(&diff_line), DedupAction::Allow);
+        // Fourth one is allowed because it has a diff msg
+        assert_eq!(deduper.dedup(&diff_msg), DedupAction::Allow);
+    }
+
+    #[test]
+    fn test_within_leeway_and_reset() {
+        let leeway = NonZeroUsize::new(2).unwrap();
+        let mut deduper = Deduper::with_leeway(leeway);
+        let record_a = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(format_args!("b"))
+            .build();
+        let record_b = Record::builder()
+            .file(Some("b"))
+            .line(Some(1))
+            .args(format_args!("b"))
+            .build();
+
+        // All should be allowed as they are within leeway and dups are reset
+        assert_eq!(deduper.dedup(&record_a), DedupAction::Allow);
+        assert_eq!(deduper.dedup(&record_a), DedupAction::Allow);
+        assert_eq!(deduper.dedup(&record_b), DedupAction::Allow);
+        assert_eq!(deduper.dedup(&record_b), DedupAction::Allow);
+        assert_eq!(deduper.dedup(&record_a), DedupAction::Allow);
+        assert_eq!(deduper.dedup(&record_a), DedupAction::Allow);
+    }
+
+    #[test]
+    fn test_leeway_warning() {
+        let leeway = NonZeroUsize::new(4).unwrap();
+        let mut deduper = Deduper::with_leeway(leeway);
+        let dup = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(format_args!("b"))
+            .build();
+
+        // First one should be allowed
+        assert_eq!(deduper.dedup(&dup), DedupAction::Allow);
+        // Silently allow the same log as long as leeway isn't met
+        for _ in 0..(deduper.leeway() - 1) {
+            assert_eq!(deduper.dedup(&dup), DedupAction::Allow);
+        }
+        // Allow last one within the leeway with a warning
+        assert_eq!(
+            deduper.dedup(&dup),
+            DedupAction::AllowLastOfLeeway(deduper.leeway())
+        );
+    }
+
+    #[test]
+    fn test_dups() {
+        let mut deduper = Deduper::with_leeway(NonZeroUsize::new(1).unwrap());
+        let dup = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(format_args!("b"))
+            .build();
+        let new_record = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(format_args!("c"))
+            .build();
+
+        // First one should be allowed
+        assert_eq!(deduper.dedup(&dup), DedupAction::Allow);
+        // Second one should be the last one allowed because of the leeway
+        assert_eq!(deduper.dedup(&dup), DedupAction::AllowLastOfLeeway(1));
+        // Third one should be skipped
+        assert_eq!(deduper.dedup(&dup), DedupAction::Skip);
+        // A new log would be allowed with the summary of the skipped ones
+        assert_eq!(
+            deduper.dedup(&new_record),
+            DedupAction::AllowAfterSkipped(1)
+        );
+    }
+
+    #[test]
+    fn test_overflowed_dups() {
+        let mut deduper = Deduper::with_leeway(NonZeroUsize::new(1).unwrap());
+        let dup = Record::builder()
+            .file(Some("a"))
+            .line(Some(1))
+            .args(format_args!("b"))
+            .build();
+
+        // Bring dups to the edge of overflow
+        deduper.duplicates = usize::MAX;
+
+        // One more dup would overflow the usize, so next one is allowed
+        assert_eq!(
+            deduper.dedup(&dup),
+            DedupAction::AllowAfterSkipped(usize::MAX - deduper.leeway())
+        );
+
+        // Dups are reset, next one is allowed as last under leeway
+        assert_eq!(
+            deduper.dedup(&dup),
+            DedupAction::AllowLastOfLeeway(deduper.leeway())
+        );
+        assert_eq!(deduper.duplicates, 1);
+    }
+}

--- a/src/flexi_logger.rs
+++ b/src/flexi_logger.rs
@@ -164,6 +164,7 @@ impl log::Log for FlexiLogger {
                             .file_static(Some(file!()))
                             .line(Some(line!()))
                             .module_path_static(Some("flexi_logger"))
+                            .target("flexi_logger")
                             .args(format_args!(
                                 "last record has been repeated consecutive times, following duplicates will be skipped...",
                             ))
@@ -178,6 +179,7 @@ impl log::Log for FlexiLogger {
                             .file_static(Some(file!()))
                             .line(Some(line!()))
                             .module_path_static(Some("flexi_logger"))
+                            .target("flexi_logger")
                             .args(format_args!("last record was skipped {} times", skipped))
                             .build(),
                     );

--- a/src/flexi_logger.rs
+++ b/src/flexi_logger.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "dedup")]
+use crate::deduper::{DedupAction, Deduper};
 use crate::primary_writer::PrimaryWriter;
 use crate::writers::LogWriter;
 use crate::LogSpecification;
@@ -5,6 +7,8 @@ use crate::LogSpecification;
 #[cfg(feature = "textfilter")]
 use regex::Regex;
 use std::collections::HashMap;
+#[cfg(feature = "dedup")]
+use std::sync::Mutex;
 use std::sync::{Arc, RwLock};
 
 // Implements log::Log to plug into the log crate.
@@ -17,6 +21,8 @@ pub(crate) struct FlexiLogger {
     log_specification: Arc<RwLock<LogSpecification>>,
     primary_writer: Arc<PrimaryWriter>,
     other_writers: Arc<HashMap<String, Box<dyn LogWriter>>>,
+    #[cfg(feature = "dedup")]
+    deduper: Option<Mutex<Deduper>>,
 }
 
 impl FlexiLogger {
@@ -24,60 +30,18 @@ impl FlexiLogger {
         log_specification: Arc<RwLock<LogSpecification>>,
         primary_writer: Arc<PrimaryWriter>,
         other_writers: Arc<HashMap<String, Box<dyn LogWriter>>>,
+        #[cfg(feature = "dedup")] deduper: Option<Deduper>,
     ) -> Self {
         Self {
             log_specification,
             primary_writer,
             other_writers,
+            #[cfg(feature = "dedup")]
+            deduper: deduper.map(Mutex::new),
         }
     }
 
-    fn primary_enabled(&self, level: log::Level, module: &str) -> bool {
-        self.log_specification.read().as_ref()
-                                .unwrap(/* catch and expose error? */)
-                                .enabled(level, module)
-    }
-}
-
-impl log::Log for FlexiLogger {
-    //  If other writers are configured and the metadata target addresses them correctly,
-    //      - we should determine if the metadata-level is digested by any of the writers
-    //        (including the primary writer)
-    //  else we fall back to default behavior:
-    //      Return true if
-    //      - target is filled with module path and level is accepted by log specification
-    //      - target is filled with crap and ???
-    //
-    // Caveat:
-    // Rocket e.g. sets target explicitly to several fantasy names;
-    // these hopefully do not collide with any of the modules in the log specification;
-    // since they do not conform with the {} syntax expected by flexi_logger, they're treated as
-    // module names.
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
-        let target = metadata.target();
-        let level = metadata.level();
-
-        if !self.other_writers.is_empty() && target.starts_with('{') {
-            // at least one other writer is configured _and_ addressed
-            let targets: Vec<&str> = target[1..(target.len() - 1)].split(',').collect();
-            for t in targets {
-                if t != "_Default" {
-                    match self.other_writers.get(t) {
-                        None => eprintln!("[flexi_logger] bad writer spec: {}", t),
-                        Some(writer) => {
-                            if level < writer.max_log_level() {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        self.primary_enabled(level, target)
-    }
-
-    fn log(&self, record: &log::Record) {
+    fn log_impl(&self, record: &log::Record) {
         let target = record.metadata().target();
         let mut now = crate::DeferredNow::new();
         if target.starts_with('{') {
@@ -134,6 +98,103 @@ impl log::Log for FlexiLogger {
             .unwrap_or_else(|e| {
                 eprintln!("[flexi_logger] writing log line failed with {}", e);
             });
+    }
+
+    fn primary_enabled(&self, level: log::Level, module: &str) -> bool {
+        self.log_specification.read().as_ref()
+                                .unwrap(/* catch and expose error? */)
+                                .enabled(level, module)
+    }
+}
+
+impl log::Log for FlexiLogger {
+    //  If other writers are configured and the metadata target addresses them correctly,
+    //      - we should determine if the metadata-level is digested by any of the writers
+    //        (including the primary writer)
+    //  else we fall back to default behavior:
+    //      Return true if
+    //      - target is filled with module path and level is accepted by log specification
+    //      - target is filled with crap and ???
+    //
+    // Caveat:
+    // Rocket e.g. sets target explicitly to several fantasy names;
+    // these hopefully do not collide with any of the modules in the log specification;
+    // since they do not conform with the {} syntax expected by flexi_logger, they're treated as
+    // module names.
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        let target = metadata.target();
+        let level = metadata.level();
+
+        if !self.other_writers.is_empty() && target.starts_with('{') {
+            // at least one other writer is configured _and_ addressed
+            let targets: Vec<&str> = target[1..(target.len() - 1)].split(',').collect();
+            for t in targets {
+                if t != "_Default" {
+                    match self.other_writers.get(t) {
+                        None => eprintln!("[flexi_logger] bad writer spec: {}", t),
+                        Some(writer) => {
+                            if level < writer.max_log_level() {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.primary_enabled(level, target)
+    }
+
+    #[cfg(feature = "dedup")]
+    fn log(&self, record: &log::Record) {
+        if let Some(deduper) = self.deduper.as_ref() {
+            let mut deduper = deduper.lock().unwrap();
+            match deduper.dedup(record) {
+                DedupAction::Allow => {
+                    // Just log
+                    self.log_impl(record);
+                }
+                DedupAction::AllowLastOfLeeway(_) => {
+                    // Log duplicate
+                    self.log_impl(record);
+                    // Log warning
+                    self.log_impl(
+                        &log::Record::builder()
+                            .level(log::Level::Warn)
+                            .file_static(Some(file!()))
+                            .line(Some(line!()))
+                            .module_path_static(Some("flexi_logger"))
+                            .args(format_args!(
+                                "last record has been repeated consecutive times, following duplicates will be skipped...",
+                            ))
+                            .build(),
+                    );
+                }
+                DedupAction::AllowAfterSkipped(skipped) => {
+                    // Log summary of skipped
+                    self.log_impl(
+                        &log::Record::builder()
+                            .level(log::Level::Info)
+                            .file_static(Some(file!()))
+                            .line(Some(line!()))
+                            .module_path_static(Some("flexi_logger"))
+                            .args(format_args!("last record was skipped {} times", skipped))
+                            .build(),
+                    );
+                    // Log new record
+                    self.log_impl(record);
+                }
+                DedupAction::Skip => return,
+            }
+        } else {
+            // Just log
+            self.log_impl(record);
+        };
+    }
+
+    #[cfg(not(feature = "dedup"))]
+    fn log(&self, record: &log::Record) {
+        self.log_impl(record);
     }
 
     fn flush(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 //! * configure the path and the filenames of the log files,
 //! * use file rotation,
 //! * specify the line format for the log lines,
+//! * use logs deduplication (i.e. log a "last record was skipped N times"
+//!   message after getting the same record for X consecutive times),
 //! * define additional log output streams, e.g for alert or security messages,
 //! * support changing the log specification while the program is running,
 //!
@@ -38,6 +40,8 @@
 //! See the documentation of method [`Logger::set_palette`]
 //! for a description how this can be done.
 
+#[cfg(feature = "dedup")]
+mod deduper;
 mod deferred_now;
 mod file_spec;
 mod flexi_error;


### PR DESCRIPTION
Hi there!

We're using `flexi_logger` with this optional feature to avoid getting a lot of noise from some loops that can log the same message a lot of times.

These changes add the ability to skip dups after some configurable leeway. Some messages are logged to summarize when and how many records were skipped.

I created the `dedup` example to demonstrate the functionality:
```log
[2021-05-27 11:02:14.412577 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.413154 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.413287 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.413433 -05:00] WARN [flexi_logger] src\flexi_logger.rs:165: last record has been repeated consecutive times, following duplicates will be skipped...
[2021-05-27 11:02:14.413713 -05:00] INFO [flexi_logger] src\flexi_logger.rs:179: last record was skipped 2 times
[2021-05-27 11:02:14.413868 -05:00] INFO [dedup] examples\dedup.rs:15: bar
[2021-05-27 11:02:14.414023 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.414302 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.414533 -05:00] INFO [dedup] examples\dedup.rs:15: foo
[2021-05-27 11:02:14.414694 -05:00] WARN [flexi_logger] src\flexi_logger.rs:165: last record has been repeated consecutive times, following duplicates will be skipped...
[2021-05-27 11:02:14.414887 -05:00] INFO [flexi_logger] src\flexi_logger.rs:179: last record was skipped 1 times
[2021-05-27 11:02:14.415021 -05:00] INFO [dedup] examples\dedup.rs:18: the end
```

Let me know what you think.