### PR TITLE
ci: refactor and add more checks/combinations

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -1,145 +1,118 @@
-on: [pull_request]
+name: CI
 
-name: CI check and lint
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
 
 jobs:
-  check_and_lint_linux:
-    name: Check test and lint Linux
+  fmt:
+    name: Check formatting
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install latest nightly with rustfmt
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: nightly
           profile: minimal
-          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+  lint:
+    name: Clippy check
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install latest nightly with clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
           override: true
           components: clippy
 
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
+      - name: Run cargo clippy without features
+        uses: actions-rs/clippy-check@v1
         with:
-          command: check
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --no-default-features -- -D warnings
 
-      - name: Run cargo check with no features
-        uses: actions-rs/cargo@v1
+      - name: Run cargo clippy with default features
+        uses: actions-rs/clippy-check@v1
         with:
-          command: check
-          args: --no-default-features
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets -- -D warnings
 
-      - name: Run cargo check with all features
-        uses: actions-rs/cargo@v1
+      - name: Run cargo clippy with all features
+        uses: actions-rs/clippy-check@v1
         with:
-          command: test
-          args: --all-features
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --all-features -- -D warnings
 
-      - name: Run cargo check with "trc"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features trc
-
-      - name: Run cargo check with "specfile"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features specfile
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
-
-  check_test_windows:
-    name: Check and test Windows
-    runs-on: windows-latest
+  build_and_test:
+    name: Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        rust: [ stable, nightly, 1.46.0 ]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: ${{ matrix.rust }}
           profile: minimal
-          toolchain: stable
           override: true
 
-      - name: Run cargo check
+      - name: Run cargo build without features
         uses: actions-rs/cargo@v1
         with:
-          command: check
-
-      - name: Run cargo check with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+          command: build
           args: --no-default-features
 
-      - name: Run cargo check with all features
+      - name: Run cargo test without features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+      - name: Run cargo build with default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - name: Run cargo test with default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo build with all features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+
+      - name: Run cargo test with all features
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
-
-      - name: Run cargo check with "trc"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features trc
-
-      - name: Run cargo check with "specfile"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features specfile
-
-  check_test_macos:
-    name: Check and test macOS
-    runs-on: macos-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-      - name: Run cargo check with no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features
-
-      - name: Run cargo check with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-
-      - name: Run cargo check with "trc"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features trc
-
-      - name: Run cargo check with "specfile"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features specfile
-
-
-
-
-

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -46,19 +46,7 @@ jobs:
           override: true
           components: clippy
 
-      - name: Run cargo clippy without features
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --no-default-features -- -D warnings
-
-      - name: Run cargo clippy with default features
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings
-
-      - name: Run cargo clippy with all features
+      - name: Run cargo clippy
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,12 +55,10 @@ jobs:
   build_and_test:
     name: Build and test
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        rust: [ stable, nightly, 1.46.0 ]
+        rust: [ stable, 1.46.0 ]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
       - uses: actions/checkout@v2
 
@@ -83,35 +69,13 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Run cargo build without features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features
-
-      - name: Run cargo test without features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
-
-      - name: Run cargo build with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - name: Run cargo test with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-      - name: Run cargo build with all features
+      - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --all-features
 
-      - name: Run cargo test with all features
+      - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
- add CI run on push on master
- add manual trigger of CI run
- refactor different combinations of OS using matrix
- add build with nightly (fail allowed) and 1.46.0 (for MSRV)
- add fmt check

actions-rs/clippy-check display a beautiful summary of warnings/errors on PR.

If there is something missing or you don't want in CI, I can make the changes.