### PR TITLE
Fix flusher thread 100% cpu usage

### DIFF
--- a/src/writers/file_log_writer/state_handle.rs
+++ b/src/writers/file_log_writer/state_handle.rs
@@ -40,7 +40,7 @@ impl SyncHandle {
                 .name("flexi_logger-flusher".to_string())
                 .stack_size(128)
                 .spawn(move || {
-                    let (_, receiver): (
+                    let (_sender, receiver): (
                         std::sync::mpsc::Sender<()>,
                         std::sync::mpsc::Receiver<()>,
                     ) = std::sync::mpsc::channel();
@@ -140,7 +140,7 @@ impl AsyncHandle {
                 .name("flexi_logger-flusher".to_string())
                 .stack_size(128)
                 .spawn(move || {
-                    let (_, receiver): (
+                    let (_sender, receiver): (
                         std::sync::mpsc::Sender<()>,
                         std::sync::mpsc::Receiver<()>,
                     ) = std::sync::mpsc::channel();


### PR DESCRIPTION
when `_` is used, the receiver is dropped immediately, causing `recv_timeout ` returns an error immediately, then cpu usage is 100%.