### PR TITLE
Remove time 0.1 from dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ trc =["async", "specfile", "tracing-subscriber"]
 [dependencies]
 atty = {version = "0.2", optional = true}
 ansi_term = {version = "0.12", optional = true}
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 crossbeam = {version = "0.8", optional = true}
 flate2 = {version = "1.0", optional = true}
 glob = "0.3"


### PR DESCRIPTION
Time 0.1 has been unsupported for a while now and has even had a RustSec advisory filed for it. `flexi_logger` does not appear to be using any functionality of the `oldtime` feature of Chrono, so I believe the dependency on `time` can be safely eliminated here.