### PR TITLE
Syslog Unix Family Fixes

### DIFF
--- a/src/writers/syslog_writer.rs
+++ b/src/writers/syslog_writer.rs
@@ -174,8 +174,8 @@ impl LogWriter for SyslogWriter {
         let mut syslog = mr_syslog.borrow_mut();
 
         let severity = (self.determine_severity)(record.level());
-        writeln!(
-            syslog,
+
+        let s = format!(
             "<{}>1 {} {:?} {} {} {} - {}",
             self.facility as u8 | severity as u8,
             now.format_rfc3339(),
@@ -184,7 +184,9 @@ impl LogWriter for SyslogWriter {
             self.pid,
             self.message_id,
             &record.args()
-        )
+        );
+        
+        syslog.write_all(s.as_bytes())
     }
 
     fn flush(&self) -> IoResult<()> {


### PR DESCRIPTION
I'm trying to get the experimental `syslog_writer` feature up and running on FreeBSD, Linux and OSX and noticed a few issues straight away. I'm opening this PR to fix the various issues I come across as I test.

The first issue is that the `cfg(target_os)` conditional used in the `syslog_writer` mod is restricted to Linux even through syslog is a Unix family standard.

This overly strict Linux restriction is something I noticed in general across flexi-logger, but I refrained from making a cross project change at this time, given that my concern is getting syslog up and running.

The second issue is that the `writeln!` macro used in `impl LogWriter for SyslogWriter` is submitting a syslog entry for each formatting placeholder. This issue will be resolved in an upcoming commit.
