### PR TITLE
add method config() 

### DIFF
--- a/src/flexi_error.rs
+++ b/src/flexi_error.rs
@@ -77,6 +77,10 @@ pub enum FlexiLoggerError {
     #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
     #[error("Logger is shut down")]
     Shutdown(#[from] crossbeam::channel::SendError<Vec<u8>>),
+
+    /// Config unavailable because not file logger is configured
+    #[error("Config unavailable because not file logger is configured")]
+    Config,
 }
 
 impl From<std::convert::Infallible> for FlexiLoggerError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub(crate) use crate::write_mode::EffectiveWriteMode;
 pub use crate::write_mode::{WriteMode, DEFAULT_BUFFER_CAPACITY, DEFAULT_FLUSH_INTERVAL};
 #[cfg(feature = "async")]
 pub use crate::write_mode::{DEFAULT_MESSAGE_CAPA, DEFAULT_POOL_CAPA};
+pub use crate::writers::file_log_writer::Config;
 
 /// Re-exports from log crate
 pub use log::{Level, LevelFilter, Record};

--- a/src/logger_handle.rs
+++ b/src/logger_handle.rs
@@ -1,7 +1,7 @@
 use crate::primary_writer::PrimaryWriter;
 use crate::util::{eprint_err, ERRCODE};
 use crate::writers::{FileLogWriterBuilder, LogWriter};
-use crate::{FlexiLoggerError, LogSpecification};
+use crate::{Config, FlexiLoggerError, LogSpecification};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -198,6 +198,21 @@ impl LoggerHandle {
             mw.reset_file_log_writer(flwb)
         } else {
             Err(FlexiLoggerError::Reset)
+        }
+    }
+
+    /// Extracts current Config of the file log writer
+    /// 
+    /// # Errors
+    ///
+    /// `FlexiLoggerError::Config` if no file log writer is configured.
+    /// `FlexiLoggerError::Io` if the specified path doesn't work.
+    /// `FlexiLoggerError::Poison` if some mutex is poisoned.
+    pub fn config(&self) -> Result<Config, FlexiLoggerError> {
+        if let PrimaryWriter::Multi(ref mw) = &*self.primary_writer {
+            mw.config()
+        } else {
+            Err(FlexiLoggerError::Config)
         }
     }
 

--- a/src/primary_writer/multi_writer.rs
+++ b/src/primary_writer/multi_writer.rs
@@ -1,7 +1,7 @@
 use crate::logger::Duplicate;
 use crate::util::write_buffered;
 use crate::writers::{FileLogWriter, FileLogWriterBuilder, LogWriter};
-use crate::{DeferredNow, FlexiLoggerError, FormatFunction};
+use crate::{Config, DeferredNow, FlexiLoggerError, FormatFunction};
 use log::Record;
 use std::io::Write;
 
@@ -41,6 +41,11 @@ impl MultiWriter {
         self.o_file_writer
             .as_ref()
             .map_or(Err(FlexiLoggerError::Reset), |flw| flw.reset(flwb))
+    }
+    pub(crate) fn config(&self) -> Result<Config, FlexiLoggerError> {
+        self.o_file_writer
+            .as_ref()
+            .map_or(Err(FlexiLoggerError::Reset), |flw| flw.config())
     }
 }
 

--- a/src/writers.rs
+++ b/src/writers.rs
@@ -98,7 +98,7 @@
 //!   ```
 //!
 
-mod file_log_writer;
+pub(crate) mod file_log_writer;
 mod log_writer;
 
 #[cfg(feature = "syslog_writer")]

--- a/src/writers/file_log_writer.rs
+++ b/src/writers/file_log_writer.rs
@@ -6,14 +6,11 @@ mod state_handle;
 
 pub use self::builder::{ArcFileLogWriter, FileLogWriterBuilder, FileLogWriterHandle};
 
-use self::{
-    config::{Config, RotationConfig},
-    state::State,
-    state_handle::StateHandle,
-};
+use self::{config::RotationConfig, state::State, state_handle::StateHandle};
 use crate::{
     writers::LogWriter, DeferredNow, EffectiveWriteMode, FileSpec, FlexiLoggerError, FormatFunction,
 };
+pub use config::Config;
 use log::Record;
 use std::path::PathBuf;
 
@@ -96,6 +93,17 @@ impl FileLogWriter {
     /// `FlexiLoggerError::Poison` if some mutex is poisoned.
     pub fn reset(&self, flwb: &FileLogWriterBuilder) -> Result<(), FlexiLoggerError> {
         self.state_handle.reset(flwb)
+    }
+
+    /// Extracts current Config of the file log writer
+    ///
+    /// # Errors
+    ///
+    /// `FlexiLoggerError::Config` if no file log writer is configured.
+    /// `FlexiLoggerError::Io` if the specified path doesn't work.
+    /// `FlexiLoggerError::Poison` if some mutex is poisoned.
+    pub fn config(&self) -> Result<Config, FlexiLoggerError> {
+        self.state_handle.config()
     }
 }
 

--- a/src/writers/file_log_writer/config.rs
+++ b/src/writers/file_log_writer/config.rs
@@ -1,9 +1,9 @@
 use crate::{Cleanup, Criterion, FileSpec, Naming, WriteMode};
 use std::path::PathBuf;
 
-// Describes how rotation should work
+/// Describes how rotation should work
 #[derive(Clone, Debug)]
-pub(crate) struct RotationConfig {
+pub struct RotationConfig {
     // Defines if rotation should be based on size or date
     pub(crate) criterion: Criterion,
     // Defines if rotated files should be numbered or get a date-based name
@@ -12,9 +12,9 @@ pub(crate) struct RotationConfig {
     pub(crate) cleanup: Cleanup,
 }
 
-// The immutable configuration of a FileLogWriter.
-#[derive(Debug)]
-pub(crate) struct Config {
+/// The immutable configuration of a `FileLogWriter`
+#[derive(Debug, Clone)]
+pub struct Config {
     pub(crate) print_message: bool,
     pub(crate) append: bool,
     pub(crate) write_mode: WriteMode,
@@ -22,4 +22,48 @@ pub(crate) struct Config {
     pub(crate) o_create_symlink: Option<PathBuf>,
     pub(crate) line_ending: &'static [u8],
     pub(crate) use_utc: bool,
+}
+
+impl Config {
+    /// Returns `file_spec` configuration
+    #[must_use]
+    pub fn directory(&self) -> &std::path::Path {
+        self.file_spec.directory.as_path()
+    }
+
+    /// Returns `basename` of log file
+    #[must_use]
+    pub fn basename(&self) -> &str {
+        &self.file_spec.basename
+    }
+
+    /// Returns `discriminant`
+    #[must_use]
+    pub fn discriminant(&self) -> Option<String> {
+        self.file_spec.o_discriminant.clone()
+    }
+
+    /// Returns `suffix`
+    #[must_use]
+    pub fn suffix(&self) -> Option<String> {
+        self.file_spec.o_suffix.clone()
+    }
+
+    /// Returns `use_utc`
+    #[must_use]
+    pub fn use_utc(&self) -> bool {
+        self.use_utc
+    }
+
+    /// Returns `append`
+    #[must_use]
+    pub fn append(&self) -> bool {
+        self.append
+    }
+
+    /// Return `print_message`
+    #[must_use]
+    pub fn print_message(&self) -> bool {
+        self.print_message
+    }
 }


### PR DESCRIPTION
Add `config()` method that extracts current Config of the file log writer

For example to find out in which directory the log is written:
```Rust
fn reset_logger(logger: Arc<Mutex<LoggerHandle>>) {
    let logger = logger.lock().unwrap();
    let logger_config = logger.config().unwrap();
    let directory = logger_config.directory(); // we need to know current directory
    let file_spec = FileSpec::default().directory(&directory).basename("basename");

    logger.reset_flw(&FileLogWriter::builder(file_spec)).unwrap();
}
