### PR TITLE
Add Clone and Copy implementations to Duplicate enum

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -891,7 +891,7 @@ pub(crate) fn log_spec_string_from_file<P: AsRef<Path>>(
 }
 
 /// Used to control which messages are to be duplicated to stderr, when `log_to_file()` is used.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Duplicate {
     /// No messages are duplicated.
     None,


### PR DESCRIPTION
This PR adds derived `Clone` and `Copy` trait implementations to the `Duplicate` enum. This allows users to more easily use a `Duplicate` value stored somewhere multiple times without resorting to weird match tricks to "copy" the value. Instead, the standard ways like deferring and calling `.clone()` will work.