### PR TITLE
Only depend on the parts of crossbeam that are used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["colors", "textfilter"]
-async = ["crossbeam"]
+async = ["crossbeam-channel", "crossbeam-queue"]
 colors = ["ansi_term", "atty"]
 compress = ["flate2"]
 dont_minimize_extra_stacks = []
@@ -43,7 +43,8 @@ use_chrono_for_offset = ["chrono"]
 atty = {version = "0.2", optional = true}
 ansi_term = {version = "0.12", optional = true}
 chrono ={version = "0.4.19", optional = true, default-features = false, features = ["clock"]}
-crossbeam = {version = "0.8", optional = true}
+crossbeam-channel = {version = "0.5", optional = true}
+crossbeam-queue = {version = "0.3", optional = true}
 flate2 = {version = "1.0", optional = true}
 glob = "0.3"
 hostname = {version = "0.3", optional = true}

--- a/src/flexi_error.rs
+++ b/src/flexi_error.rs
@@ -80,7 +80,7 @@ pub enum FlexiLoggerError {
     #[cfg(feature = "async")]
     #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
     #[error("Logger is shut down")]
-    Shutdown(#[from] crossbeam::channel::SendError<Vec<u8>>),
+    Shutdown(#[from] crossbeam_channel::SendError<Vec<u8>>),
 }
 
 impl From<std::convert::Infallible> for FlexiLoggerError {

--- a/src/primary_writer/std_writer.rs
+++ b/src/primary_writer/std_writer.rs
@@ -1,10 +1,8 @@
 #[cfg(feature = "async")]
 use {
     crate::util::{eprint_err, ASYNC_FLUSH, ASYNC_SHUTDOWN, ERRCODE},
-    crossbeam::{
-        channel::{self, SendError, Sender},
-        queue::ArrayQueue,
-    },
+    crossbeam_channel::{self, SendError, Sender},
+    crossbeam_queue::ArrayQueue,
 };
 
 use {
@@ -57,7 +55,7 @@ impl AsyncHandle {
         msg_capa: usize,
         #[cfg(test)] validation_buffer: &Arc<Mutex<Cursor<Vec<u8>>>>,
     ) -> Self {
-        let (sender, receiver) = channel::unbounded::<Vec<u8>>();
+        let (sender, receiver) = crossbeam_channel::unbounded::<Vec<u8>>();
         let a_pool = Arc::new(ArrayQueue::new(pool_capa));
 
         let mo_thread_handle = crate::threads::start_async_stdwriter(

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -19,7 +19,8 @@ use {
         primary_writer::std_stream::StdStream,
         util::{ASYNC_FLUSH, ASYNC_SHUTDOWN},
     },
-    crossbeam::{channel::Receiver as CrossbeamReceiver, queue::ArrayQueue},
+    crossbeam_channel::Receiver as CrossbeamReceiver,
+    crossbeam_queue::ArrayQueue,
     std::{sync::Mutex, thread::JoinHandle},
 };
 

--- a/src/writers/file_log_writer/state_handle.rs
+++ b/src/writers/file_log_writer/state_handle.rs
@@ -3,13 +3,13 @@ use crate::util::{buffer_with, eprint_err, io_err, ERRCODE};
 #[cfg(feature = "async")]
 use crate::util::{ASYNC_FLUSH, ASYNC_SHUTDOWN};
 use crate::{DeferredNow, FlexiLoggerError, FormatFunction};
-#[cfg(feature = "async")]
-use crossbeam::{channel::Sender, queue::ArrayQueue};
 use log::Record;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "async")]
 use std::thread::JoinHandle;
+#[cfg(feature = "async")]
+use {crossbeam_channel::Sender, crossbeam_queue::ArrayQueue};
 
 #[derive(Debug)]
 pub(super) enum StateHandle {

--- a/src/writers/file_log_writer/threads.rs
+++ b/src/writers/file_log_writer/threads.rs
@@ -15,10 +15,8 @@ use {
 #[cfg(feature = "async")]
 use {
     crate::util::{eprint_err, eprint_msg, ASYNC_FLUSH, ASYNC_SHUTDOWN, ERRCODE},
-    crossbeam::{
-        channel::{self, Sender as CrossbeamSender},
-        queue::ArrayQueue,
-    },
+    crossbeam_channel::{self, Sender as CrossbeamSender},
+    crossbeam_queue::ArrayQueue,
 };
 
 const CLEANER: &str = "flexi_logger-fs-cleanup";
@@ -74,7 +72,7 @@ pub(super) fn start_async_fs_writer(
     message_capa: usize,
     a_pool: Arc<ArrayQueue<Vec<u8>>>,
 ) -> (CrossbeamSender<Vec<u8>>, Mutex<Option<JoinHandle<()>>>) {
-    let (sender, receiver) = channel::unbounded::<Vec<u8>>();
+    let (sender, receiver) = crossbeam_channel::unbounded::<Vec<u8>>();
     (
         sender,
         Mutex::new(Some(


### PR DESCRIPTION
Less transitive dependencies for projects that use flexi_logger to
build.