### PR TITLE
Raise version of notify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ glob = "0.3"
 hostname = {version = "0.3", optional = true}
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }
-notify = { version = "4.0", optional = true }
+notify = { version = "5.0", optional = true }
 regex = { version = "1.1", optional = true }
 rustversion = "1.0"
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
The previous version of notify has the dependency chain:

      notify 4 -> mio 0.6 -> net2 0.2

Where net2 has a security advisory: https://rustsec.org/advisories/RUSTSEC-2020-0016
The latest version of notify does not have this dependency.