### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ other output streams, and that can be influenced while the program is running.**
 [![Latest version](https://img.shields.io/crates/v/flexi_logger.svg)](https://crates.io/crates/flexi_logger)
 [![Documentation](https://docs.rs/flexi_logger/badge.svg)](https://docs.rs/flexi_logger)
 [![License](https://img.shields.io/crates/l/flexi_logger.svg)](https://github.com/emabee/flexi_logger)
-[![Build](https://img.shields.io/github/workflow/status/emabee/flexi_logger/CI/master)](https://github.com/emabee/flexi_logger/actions?query=workflow%3ACI)
+[![Build](https://img.shields.io/github/actions/workflow/status/emabee/flexi_logger/ci_test.yml?branch=master)](https://github.com/emabee/flexi_logger/actions?query=workflow%3ACI)
 
 ## Usage
 


### PR DESCRIPTION
The url for badges has changed and the current one displays a link to the github issue mentioning the change. This edit makes the change to the new url so that the CI build status badge works correctly see https://github.com/badges/shields/issues/8671