### PR TITLE
Ability to create only date log file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/*logspec.toml
 *~
 .*~
 .vscode
+.idea/

--- a/src/file_spec.rs
+++ b/src/file_spec.rs
@@ -96,9 +96,11 @@ impl FileSpec {
         }
     }
 
-    /// Excludes the basename from the log filename.
+    /// Makes the logger not include a basename into the names of the log files
+    ///
+    /// Equivalent to `basename("")`.
     #[must_use]
-    pub fn no_basename(mut self) -> Self {
+    pub fn suppress_basename(mut self) -> Self {
         self.basename = "".into();
         self
     }

--- a/src/file_spec.rs
+++ b/src/file_spec.rs
@@ -96,6 +96,13 @@ impl FileSpec {
         }
     }
 
+    /// Excludes the basename from the log filename.
+    #[must_use]
+    pub fn no_basename(mut self) -> Self {
+        self.basename = "".into();
+        self
+    }
+
     /// The specified String is used as the basename of the log file name,
     /// instead of the program name. Using a file separator within the argument is discouraged.
     #[must_use]
@@ -214,10 +221,11 @@ impl FileSpec {
         filename.reserve(50);
 
         if let Some(discriminant) = &self.o_discriminant {
-            filename.push('_');
+            if !filename.is_empty() { filename.push('_'); }
             filename.push_str(discriminant);
         }
         if let Some(timestamp) = &self.timestamp_cfg.get_timestamp() {
+            if !filename.is_empty() { filename.push('_'); }
             filename.push_str(timestamp);
         }
         if let Some(infix) = o_infix {
@@ -239,10 +247,11 @@ impl FileSpec {
         filename.reserve(50);
 
         if let Some(discriminant) = &self.o_discriminant {
-            filename.push('_');
+            if !filename.is_empty() { filename.push('_'); }
             filename.push_str(discriminant);
         }
         if let Some(timestamp) = &self.timestamp_cfg.get_timestamp() {
+            if !filename.is_empty() { filename.push('_'); }
             filename.push_str(timestamp);
         }
         filename.push_str(infix_pattern);
@@ -266,7 +275,7 @@ impl FileSpec {
     }
 }
 
-const TS_USCORE_DASHES_USCORE_DASHES: &str = "_%Y-%m-%d_%H-%M-%S";
+const TS_USCORE_DASHES_USCORE_DASHES: &str = "%Y-%m-%d_%H-%M-%S";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum TimestampCfg {

--- a/tests/test_file_writer.rs
+++ b/tests/test_file_writer.rs
@@ -77,14 +77,14 @@ fn work(value: u8) {
             logger = logger.format(opt_format).log_to_file(
                 FileSpec::default()
                   .directory(self::test_utils::dir())
-                  .no_basename(),
+                  .suppress_basename(),
             );
         }
         7 => {
             logger = logger.format(opt_format).log_to_file(
                 FileSpec::default()
                   .directory(self::test_utils::dir())
-                  .no_basename()
+                  .suppress_basename()
                   .discriminant("foo"),
             );
         }

--- a/tests/test_file_writer.rs
+++ b/tests/test_file_writer.rs
@@ -3,7 +3,7 @@ mod test_utils;
 use flexi_logger::{detailed_format, opt_format, Cleanup, Criterion, FileSpec, Logger, Naming};
 use log::*;
 
-const COUNT: u8 = 6;
+const COUNT: u8 = 8;
 
 #[test]
 fn test_write_modes() {
@@ -71,6 +71,21 @@ fn work(value: u8) {
                     .suppress_timestamp()
                     .directory(self::test_utils::dir())
                     .discriminant("foo"),
+            );
+        }
+        6 => {
+            logger = logger.format(opt_format).log_to_file(
+                FileSpec::default()
+                  .directory(self::test_utils::dir())
+                  .no_basename(),
+            );
+        }
+        7 => {
+            logger = logger.format(opt_format).log_to_file(
+                FileSpec::default()
+                  .directory(self::test_utils::dir())
+                  .no_basename()
+                  .discriminant("foo"),
             );
         }
         COUNT..=u8::MAX => {


### PR DESCRIPTION
Previously, it was not possible to create `FileSpec` for creating log file only with date in its name because if `basename` was set to an empty string then there was an underscore before date (`_2024-01-14_00-43-30.log`). Now if `basename` is an empty string then there is no underscore at the beginning (`2024-01-14_00-43-30.log`). Also added `suppress_basename()` function to `FileSpec` that just sets `basename` to an empty string.

Now, this:
```rust
FileSpec::default()
  .directory("logs")
  .suppress_basename();
```
will give you file path: `logs/2024-01-14_00-43-30.log`.

Previously only this was possible:
```rust
FileSpec::default()
  .directory("logs")
  .basename("");
```
but it was giving: `logs/_2024-01-14_00-43-30.log`.