### PR TITLE
add custom infix and rotation date time format

### DIFF
--- a/src/file_spec.rs
+++ b/src/file_spec.rs
@@ -192,7 +192,7 @@ impl FileSpec {
         self
     }
 
-    // If no decison was done yet, decide now whether to include a timestamp
+    // If no decision was done yet, decide now whether to include a timestamp
     // into the names of the log files.
     pub(crate) fn if_default_use_timestamp(&mut self, use_timestamp: bool) {
         if let TimestampCfg::Default = self.timestamp_cfg {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -100,6 +100,16 @@ pub enum Naming {
     /// `"_r2023-01-27_14-41-08.restart-0001"`.
     TimestampsDirect,
 
+    /// Logs are written to a file with a custom infix and timestamp-infix,
+    /// like `("_myCURRENT", "_%Y-%m-%d")` gives "_myCURRENT" and after rotation `"_2023-01-27"`.
+    /// `("", "_%Y-%m-%d")` would skipped any infix on current file.
+    ///
+    /// File rotation switches over to the next file.
+    ///
+    /// If multiple rotations happen within the same second, extended infixes are used like
+    /// `"_2023-01-27.restart-0001"`.
+    TimestampsFormat((&'static str, &'static str)),
+
     /// Logs are written to a file with infix `_rCURRENT`.
     ///
     /// File rotation renames this file to a name with a number-infix


### PR DESCRIPTION
I followed your [suggestion](https://github.com/emabee/flexi_logger/issues/158#issuecomment-2146170978), but without chatGPT... 

This pull request introduce a new naming element for file rotations. Examples:

- `Naming::TimestampsFormat(("", "_%Y-%m-%d"))` would result in: `{basename}.log` for current file and `{basename}_2024-06-03.log` after rotation.
- `Naming::TimestampsFormat(("_myCURRENT", "_%Y-%m-%d"))` would result in: `{basename}_myCURRENT.log` for current file and `{basename}_2024-06-03.log` after rotation.