### PR TITLE
Remove unnecessary dependency and implement a Trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["colors", "textfilter"]
 async = ["dep:crossbeam-channel", "dep:crossbeam-queue"]
-colors = ["dep:nu-ansi-term", "is-terminal"]
+colors = ["dep:nu-ansi-term"]
 compress = ["dep:flate2"]
 dont_minimize_extra_stacks = []
 json = ["dep:serde_json", "dep:serde", "dep:serde_derive"]
@@ -42,7 +42,6 @@ textfilter = ["dep:regex"]
 trc = ["async", "specfile", "dep:tracing", "dep:tracing-subscriber"]
 
 [dependencies]
-is-terminal = { version = "0.4", optional = true }
 nu-ansi-term = { version = "0.50", optional = true }
 chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 crossbeam-channel = { version = "0.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ The default feature `colors` simplifies this by doing three things:
 * provides additional colored pendants to the existing uncolored format functions
 * it uses `colored_default_format()` for the output to stderr,
   and the non-colored `default_format()` for the output to files
-* it activates the optional dependency to `is-terminal` to being able to switch off
-  coloring if the output is not sent to a terminal but e.g. piped to another program.
+* it switches off coloring if the output is not sent to a terminal but e.g. piped to another program.
 
 **<span style="color:red">C</span><span style="color:blue">o</span><span
 style="color:green">l</span><span style="color:orange">o</span><span
@@ -116,7 +115,7 @@ style="color:magenta">r</span><span style="color:darkturquoise">s</span>**,
 or styles in general, are a matter of taste, and no choice will fit every need.
 So you can override the default formatting and coloring in various ways.
 
-With switching off the default features and choosing feature `is-terminal` explicitly
+With switching off the default features
 (see [usage](#usage)) you can remove the `nu_ansi_term`-based coloring
 but keep the capability to switch off your own coloring.
 

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -4,7 +4,7 @@ fn main() {
 
     #[cfg(feature = "colors")]
     {
-        use is_terminal::IsTerminal;
+        use std::io::IsTerminal;
         use nu_ansi_term::Color;
 
         for i in 0..=255 {

--- a/examples/colors2.rs
+++ b/examples/colors2.rs
@@ -9,7 +9,7 @@ fn main() {
 
     //     #[cfg(feature = "colors")]
     //     {
-    //         use is_terminal::IsTerminal;;
+    //         use std::io::IsTerminal;;
 
     //         colored::control::set_override(true);
 

--- a/scripts/qualify.rs
+++ b/scripts/qualify.rs
@@ -55,7 +55,6 @@ fn main() {
     run_command!("cargo build");
     run_command!("cargo build --no-default-features");
     #[rustfmt::skip]
-    run_command!("cargo build --no-default-features --features=is-terminal");
     run_command!("cargo build --all-features");
     run_command!("cargo build --release");
     run_command!("cargo build --release --all-features");

--- a/src/code_examples.md
+++ b/src/code_examples.md
@@ -259,10 +259,8 @@ by providing one of the variants of [`AdaptiveFormat`](crate::AdaptiveFormat) to
 format method, e.g.
 
 ```rust
-# #[cfg(feature = "is-terminal")]
 # use flexi_logger::AdaptiveFormat;
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-# #[cfg(feature = "is-terminal")]
 # {
       flexi_logger::Logger::try_with_str("info")?
           .adaptive_format_for_stderr(AdaptiveFormat::Detailed);
@@ -276,7 +274,6 @@ format method, e.g.
 `flexi_logger` initializes by default equivalently to this:
 
 ```rust
-# #[cfg(feature = "is-terminal")]
 # mod example {
 # use flexi_logger::{Logger,AdaptiveFormat,default_format, FileSpec};
 # use log::{debug, error, info, trace, warn};

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -455,8 +455,6 @@ fn parse_style(input: &str) -> Result<Style, std::num::ParseIntError> {
 ///
 /// This is helpful if the output is sometimes piped into other programs, which usually
 /// do not expect color control byte sequences.
-#[cfg_attr(docsrs, doc(cfg(feature = "is-terminal")))]
-#[cfg(feature = "is-terminal")]
 #[derive(Clone, Copy)]
 pub enum AdaptiveFormat {
     /// Chooses between [`default_format`](crate::default_format)
@@ -487,7 +485,6 @@ pub enum AdaptiveFormat {
     Custom(FormatFunction, FormatFunction),
 }
 
-#[cfg(feature = "is-terminal")]
 impl AdaptiveFormat {
     #[must_use]
     pub(crate) fn format_function(self, is_tty: bool) -> FormatFunction {

--- a/src/log_specification.rs
+++ b/src/log_specification.rs
@@ -462,6 +462,19 @@ impl std::convert::TryFrom<&String> for LogSpecification {
     }
 }
 
+impl From<LevelFilter> for LogSpecification {
+    fn from(value: LevelFilter) -> Self {
+        match value {
+            LevelFilter::Error => LogSpecification::error(),
+            LevelFilter::Warn => LogSpecification::warn(),
+            LevelFilter::Info => LogSpecification::info(),
+            LevelFilter::Debug => LogSpecification::debug(),
+            LevelFilter::Trace => LogSpecification::trace(),
+            LevelFilter::Off => LogSpecification::off(),
+        }
+    }
+}
+
 fn push_err(s: &str, parse_errs: &mut String) {
     if !parse_errs.is_empty() {
         parse_errs.push_str("; ");

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "is-terminal")]
 use crate::formats::AdaptiveFormat;
 use crate::{
     filter::LogLineFilter,
@@ -11,8 +10,8 @@ use crate::{
     Cleanup, Criterion, DeferredNow, FileSpec, FlexiLoggerError, FormatFunction, LogSpecification,
     LoggerHandle, Naming, WriteMode,
 };
-#[cfg(feature = "is-terminal")]
-use is_terminal::IsTerminal;
+
+use std::io::IsTerminal;
 use log::LevelFilter;
 #[cfg(feature = "specfile")]
 use std::sync::Mutex;
@@ -136,19 +135,11 @@ impl Logger {
 
             #[cfg(feature = "colors")]
             format_for_stdout: AdaptiveFormat::Default.format_function(
-                if cfg!(feature = "is-terminal") {
                     std::io::stdout().is_terminal()
-                } else {
-                    false
-                },
             ),
             #[cfg(feature = "colors")]
             format_for_stderr: AdaptiveFormat::Default.format_function(
-                if cfg!(feature = "is-terminal") {
                     std::io::stderr().is_terminal()
-                } else {
-                    false
-                },
             ),
 
             #[cfg(not(feature = "colors"))]
@@ -311,8 +302,6 @@ impl Logger {
     /// Coloring is used if `stderr` is a tty.
     ///
     /// Regarding the default, see [`Logger::format`].
-    #[cfg_attr(docsrs, doc(cfg(feature = "is-terminal")))]
-    #[cfg(feature = "is-terminal")]
     #[must_use]
     pub fn adaptive_format_for_stderr(mut self, adaptive_format: AdaptiveFormat) -> Self {
         self.format_for_stderr = adaptive_format.format_function(std::io::stderr().is_terminal());
@@ -333,8 +322,6 @@ impl Logger {
     /// Coloring is used if `stdout` is a tty.
     ///
     /// Regarding the default, see [`Logger::format`].
-    #[cfg_attr(docsrs, doc(cfg(feature = "is-terminal")))]
-    #[cfg(feature = "is-terminal")]
     #[must_use]
     pub fn adaptive_format_for_stdout(mut self, adaptive_format: AdaptiveFormat) -> Self {
         self.format_for_stdout = adaptive_format.format_function(std::io::stdout().is_terminal());


### PR DESCRIPTION
Since rust version `1.70.0` (which is also the MSRV of this crate), the unstable std feature `is-terminal` has been stabilized.

Apart from that, implemented `From<LevelFilter> for LogSpecification`

PS.
Before merging, you might wanna update the `CHANGELOG`