### PR TITLE
Allow defining own infix formatter

### DIFF
--- a/examples/rotate_custom_format.rs
+++ b/examples/rotate_custom_format.rs
@@ -1,0 +1,43 @@
+use flexi_logger::{
+    sort_by_creation_date, Age, Cleanup, Criterion, CustomFormatter, Duplicate, FileSorter,
+    FileSpec, FlexiLoggerError, LevelFilter, Logger, Naming,
+};
+use std::{thread::sleep, time::Duration};
+
+fn format_infix(o_last_infix: Option<String>) -> String {
+    let id = match o_last_infix {
+        Some(infix) => {
+            let id: usize = infix.parse().unwrap();
+            id + 1
+        }
+        None => 0,
+    };
+    id.to_string()
+}
+
+fn main() -> Result<(), FlexiLoggerError> {
+    Logger::with(LevelFilter::Info)
+        .rotate(
+            Criterion::Age(Age::Second),
+            Naming::CustomFormat(CustomFormatter::new(format_infix)),
+            Cleanup::KeepLogFiles(4),
+        )
+        .log_to_file(
+            FileSpec::default()
+                .directory(std::env::current_dir().unwrap().join("log_files"))
+                .basename("app-log")
+                .suffix("txt")
+                .file_sorter(FileSorter::new(sort_by_creation_date)),
+        )
+        .duplicate_to_stdout(Duplicate::All)
+        .start()?;
+
+    log::info!("start");
+    for step in 0..30 {
+        log::info!("step {}", step);
+        sleep(Duration::from_millis(250));
+    }
+    log::info!("done");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ pub use crate::{
     log_specification::{LogSpecBuilder, LogSpecification, ModuleFilter},
     logger::{Duplicate, ErrorChannel, Logger},
     logger_handle::{LogfileSelector, LoggerHandle},
-    parameters::{Age, Cleanup, Criterion, FileSpec, Naming},
+    parameters::{
+        sort_by_creation_date, sort_by_default, Age, Cleanup, Criterion, CustomFormatter,
+        FileSorter, FileSpec, Naming,
+    },
     write_mode::{WriteMode, DEFAULT_BUFFER_CAPACITY, DEFAULT_FLUSH_INTERVAL},
 };
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -7,5 +7,7 @@ mod naming;
 pub use age::Age;
 pub use cleanup::Cleanup;
 pub use criterion::Criterion;
-pub use file_spec::FileSpec;
+pub use file_spec::{sort_by_creation_date, sort_by_default};
+pub use file_spec::{FileSorter, FileSpec};
+pub use naming::CustomFormatter;
 pub use naming::Naming;

--- a/src/parameters/naming.rs
+++ b/src/parameters/naming.rs
@@ -103,7 +103,11 @@ pub enum Naming {
     ///
     /// File rotation switches over to the next file.
     NumbersDirect,
+
+    /// Allows to specify custom infix and treat each file with basename as log file
+    CustomFormat(CustomFormatter),
 }
+
 impl Naming {
     pub(crate) fn writes_direct(self) -> bool {
         matches!(
@@ -115,5 +119,23 @@ impl Naming {
                     format: _
                 }
         )
+    }
+}
+
+/// Custom Formatter
+#[derive(Copy, Clone, Debug)]
+pub struct CustomFormatter {
+    format_fn: fn(Option<String>) -> String,
+}
+
+impl CustomFormatter {
+    /// Instantiate custom formatter
+    pub fn new(format_fn: fn(Option<String>) -> String) -> Self {
+        CustomFormatter { format_fn }
+    }
+
+    /// call custom formatter
+    pub fn call(&self, o_last_infix: Option<String>) -> String {
+        (self.format_fn)(o_last_infix)
     }
 }

--- a/src/writers/file_log_writer/infix_filter.rs
+++ b/src/writers/file_log_writer/infix_filter.rs
@@ -27,7 +27,7 @@ impl InfixFilter {
             #[cfg(test)]
             InfixFilter::StartsWth(s) => infix.starts_with(s),
             InfixFilter::Equls(s) => infix.eq(s),
-            InfixFilter::None => false,
+            InfixFilter::None => true,
         }
     }
 }

--- a/src/writers/file_log_writer/state/list_and_cleanup.rs
+++ b/src/writers/file_log_writer/state/list_and_cleanup.rs
@@ -197,3 +197,16 @@ pub(super) fn start_cleanup_thread(
         })?,
     })
 }
+
+pub(super) fn get_last_infix(file_spec: &FileSpec) -> Option<String> {
+    let log_files =
+        super::list_and_cleanup::list_of_log_and_compressed_files(file_spec, &InfixFilter::None);
+    // ascending ordering
+    let last_log_file = log_files.first()?;
+    let last_log_name = last_log_file.file_stem().unwrap(/*ok*/).to_string_lossy();
+    Some(
+        last_log_name
+            .strip_prefix(&format!("{}_", file_spec.get_basename()))?
+            .to_owned(),
+    )
+}


### PR DESCRIPTION
I created a draft that allows defining a user-specific infix. This has a use case when e.g. there is some external tool that expects the log files to have a certain name.

There are probably some corner cases still to be handled and some work to split the functionality into separate/different files. This can be done once the general idea is accepted.

I think it would be good to also handle "_" separator, but it seems it requires quite some work.