### PR TITLE
Fix Changelog versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.8] - 2024-12-18
+## [0.29.8] - 2024-12-18
 
 Fix issue #185.
 
-## [0.25.7] - 2024-12-10
+## [0.29.7] - 2024-12-10
 
 Fix issue #184.
 
@@ -17,12 +17,12 @@ Update dependencies.
 
 Bump minimal supported rust version to 1.72.0.
 
-## [0.25.6] - 2024-11-02
+## [0.29.6] - 2024-11-02
 
 Allow for custom process names when using the syslog writer (PR #182, kudos to
 [Julien JPK](https://github.com/julienjpk-withings)).
 
-## [0.25.5] - 2024-10-29
+## [0.29.5] - 2024-10-29
 
 Fix [issue #181](https://github.com/emabee/flexi_logger/issues/181).
 


### PR DESCRIPTION
It looks like the most recent versions in the changelog were accidentally typed as 0.25.x.  This PR updates them to 0.29.x.