### PR TITLE
feature: add `syslog` call based `SyslogWriter` connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ json = ["dep:serde_json", "dep:serde", "dep:serde_derive"]
 kv = ["log/kv_serde"]
 specfile = ["specfile_without_notification", "dep:notify-debouncer-mini"]
 specfile_without_notification = ["dep:serde", "dep:toml", "dep:serde_derive"]
-syslog_writer = ["dep:libc", "dep:hostname"]
+syslog_writer = ["dep:nix", "dep:hostname"]
 textfilter = ["dep:regex"]
 trc = ["async", "specfile", "dep:tracing", "dep:tracing-subscriber"]
 
@@ -47,7 +47,6 @@ chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
 crossbeam-channel = { version = "0.5", optional = true }
 crossbeam-queue = { version = "0.3", optional = true }
 flate2 = { version = "1.0", optional = true, features = ["rust_backend"] }
-hostname = { version = "0.4", optional = true }
 log = { version = "0.4", features = ["std"] }
 notify-debouncer-mini = { version = "0.6", optional = true, default-features = false }
 regex = { version = "1.1", optional = true }
@@ -61,8 +60,11 @@ tracing-subscriber = { version = "0.3", optional = true, features = [
     "env-filter",
 ] }
 
-[target.'cfg(linux)'.dependencies]
-libc = { version = "^0.2.50", optional = true }
+[target.'cfg(not(unix))'.dependencies]
+hostname = { version = "0.4", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30.1", optional = true, features = ["hostname", "syslog"] }
 
 [dev-dependencies]
 cond_sync = "0.2"

--- a/src/writers/syslog/connection.rs
+++ b/src/writers/syslog/connection.rs
@@ -6,41 +6,46 @@ use std::{
 // Writable and flushable connection to the syslog backend.
 #[derive(Debug)]
 pub(super) enum Connection {
-    // Sends log lines to the syslog via a
-    // [UnixStream](https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html).
-    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
-    #[cfg(target_family = "unix")]
+    /// Sends log lines to the syslog via a
+    /// [UnixStream](https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html).
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
     Stream(std::os::unix::net::UnixStream),
 
-    // Sends log lines to the syslog via a
-    // [UnixDatagram](https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html).
-    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
-    #[cfg(target_family = "unix")]
+    /// Sends log lines to the syslog via a
+    /// [UnixDatagram](https://doc.rust-lang.org/std/os/unix/net/struct.UnixDatagram.html).
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
     Datagram(std::os::unix::net::UnixDatagram),
 
-    // Sends log lines to the syslog via UDP.
-    //
-    // UDP is fragile and thus discouraged except for local communication.
+    /// Sends log lines to the local syslog using the `syslog` C function.
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
+    SyslogCall,
+
+    /// Sends log lines to the syslog via UDP.
     Udp(UdpSocket),
 
-    // Sends log lines to the syslog via TCP.
+    /// Sends log lines to the syslog via TCP.
     Tcp(TcpStream),
 }
 
 impl Write for Connection {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match *self {
-            #[cfg(target_family = "unix")]
+            #[cfg(unix)]
             Self::Datagram(ref ud) => {
                 // todo: reconnect if conn is broken
                 ud.send(buf)
             }
-            #[cfg(target_family = "unix")]
+            #[cfg(unix)]
             Self::Stream(ref mut w) => {
                 // todo: reconnect if conn is broken
                 w.write(buf)
                     .and_then(|sz| w.write_all(&[0; 1]).map(|()| sz))
             }
+            #[cfg(unix)]
+            Self::SyslogCall => Ok(buf.len()), // `syslog` needs a priority value, which has to be provided by an upper layer
             Self::Tcp(ref mut w) => {
                 // todo: reconnect if conn is broken
                 let n = w.write(buf)?;
@@ -55,11 +60,14 @@ impl Write for Connection {
 
     fn flush(&mut self) -> IoResult<()> {
         match *self {
-            #[cfg(target_family = "unix")]
+            #[cfg(unix)]
             Self::Datagram(_) => Ok(()),
 
-            #[cfg(target_family = "unix")]
+            #[cfg(unix)]
             Self::Stream(ref mut w) => w.flush(),
+
+            #[cfg(unix)]
+            Self::SyslogCall => Ok(()),
 
             Self::Udp(_) => Ok(()),
 

--- a/src/writers/syslog/facility.rs
+++ b/src/writers/syslog/facility.rs
@@ -53,3 +53,35 @@ pub enum SyslogFacility {
     /// local use 7  (local7).
     LocalUse7 = 23 << 3,
 }
+
+#[cfg(unix)]
+impl SyslogFacility {
+    pub(crate) fn to_nix(self) -> nix::syslog::Facility {
+        match self {
+            SyslogFacility::Kernel => nix::syslog::Facility::LOG_KERN,
+            SyslogFacility::UserLevel => nix::syslog::Facility::LOG_USER,
+            SyslogFacility::MailSystem => nix::syslog::Facility::LOG_MAIL,
+            SyslogFacility::SystemDaemons => nix::syslog::Facility::LOG_DAEMON,
+            SyslogFacility::Authorization => nix::syslog::Facility::LOG_AUTH,
+            SyslogFacility::SyslogD => nix::syslog::Facility::LOG_SYSLOG,
+            SyslogFacility::LinePrinter => nix::syslog::Facility::LOG_LPR,
+            SyslogFacility::News => nix::syslog::Facility::LOG_NEWS,
+            SyslogFacility::Uucp => nix::syslog::Facility::LOG_UUCP,
+            SyslogFacility::Clock => nix::syslog::Facility::LOG_DAEMON,
+            SyslogFacility::Authorization2 => nix::syslog::Facility::LOG_AUTH,
+            SyslogFacility::Ftp => nix::syslog::Facility::LOG_DAEMON,
+            SyslogFacility::Ntp => nix::syslog::Facility::LOG_DAEMON,
+            SyslogFacility::LogAudit => nix::syslog::Facility::LOG_USER,
+            SyslogFacility::LogAlert => nix::syslog::Facility::LOG_USER,
+            SyslogFacility::Clock2 => nix::syslog::Facility::LOG_DAEMON,
+            SyslogFacility::LocalUse0 => nix::syslog::Facility::LOG_LOCAL0,
+            SyslogFacility::LocalUse1 => nix::syslog::Facility::LOG_LOCAL1,
+            SyslogFacility::LocalUse2 => nix::syslog::Facility::LOG_LOCAL2,
+            SyslogFacility::LocalUse3 => nix::syslog::Facility::LOG_LOCAL3,
+            SyslogFacility::LocalUse4 => nix::syslog::Facility::LOG_LOCAL4,
+            SyslogFacility::LocalUse5 => nix::syslog::Facility::LOG_LOCAL5,
+            SyslogFacility::LocalUse6 => nix::syslog::Facility::LOG_LOCAL6,
+            SyslogFacility::LocalUse7 => nix::syslog::Facility::LOG_LOCAL7,
+        }
+    }
+}

--- a/src/writers/syslog/severity.rs
+++ b/src/writers/syslog/severity.rs
@@ -35,3 +35,19 @@ pub(crate) fn default_mapping(level: log::Level) -> SyslogSeverity {
         log::Level::Debug | log::Level::Trace => SyslogSeverity::Debug,
     }
 }
+
+#[cfg(unix)]
+impl SyslogSeverity {
+    pub(crate) fn to_nix(self) -> nix::syslog::Severity {
+        match self {
+            SyslogSeverity::Emergency => nix::syslog::Severity::LOG_EMERG.into(),
+            SyslogSeverity::Alert => nix::syslog::Severity::LOG_ALERT.into(),
+            SyslogSeverity::Critical => nix::syslog::Severity::LOG_CRIT.into(),
+            SyslogSeverity::Error => nix::syslog::Severity::LOG_ERR.into(),
+            SyslogSeverity::Warning => nix::syslog::Severity::LOG_WARNING.into(),
+            SyslogSeverity::Notice => nix::syslog::Severity::LOG_NOTICE.into(),
+            SyslogSeverity::Info => nix::syslog::Severity::LOG_INFO.into(),
+            SyslogSeverity::Debug => nix::syslog::Severity::LOG_DEBUG.into(),
+        }
+    }
+}

--- a/src/writers/syslog/syslog_connection.rs
+++ b/src/writers/syslog/syslog_connection.rs
@@ -55,7 +55,7 @@ impl SyslogConnection {
     /// of log messages.
     ///
     /// Because the `syslog` function has its own internal and opaque process-wide
-    /// state, this connection assumes that no code external to the logger in will
+    /// state, this connection assumes that no code external to the logger will
     /// attempt to set up the `syslog` function with different parameters.
     ///
     /// For reference, on Linux with `musl` or `glibc`, the `syslog` function

--- a/src/writers/syslog/syslog_connection.rs
+++ b/src/writers/syslog/syslog_connection.rs
@@ -1,5 +1,6 @@
 use super::connection::Connection;
-#[cfg(target_family = "unix")]
+
+#[cfg(unix)]
 use std::path::Path;
 use std::{
     io::Result as IoResult,
@@ -21,8 +22,8 @@ impl SyslogConnection {
     /// # Errors
     ///
     /// Any kind of I/O error can occur.
-    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
-    #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
     pub fn try_datagram<P: AsRef<Path>>(path: P) -> IoResult<Self> {
         let ud = std::os::unix::net::UnixDatagram::unbound()?;
         ud.connect(&path)?;
@@ -34,12 +35,44 @@ impl SyslogConnection {
     /// # Errors
     ///
     /// Any kind of I/O error can occur.
-    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
-    #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
     pub fn try_stream<P: AsRef<Path>>(path: P) -> IoResult<Self> {
         Ok(SyslogConnection(Connection::Stream(
             std::os::unix::net::UnixStream::connect(path)?,
         )))
+    }
+
+    /// Returns a `Syslog` that delegates on the POSIX-standard [`syslog` C function]
+    /// provided by the platform's standard C library to send logs.
+    ///
+    /// This is ideal for portably sending logs to whatever system logging service
+    /// may be available, which might not always be listening on a socket and be
+    /// configured with varying policies for log delivery and storage.
+    ///
+    /// The value of `SyslogLineHeader` is ignored when using this connection type,
+    /// as the `syslog` function entirely handles the delivery protocol and formatting
+    /// of log messages.
+    ///
+    /// Because the `syslog` function has its own internal and opaque process-wide
+    /// state, this connection assumes that no code external to the logger in will
+    /// attempt to set up the `syslog` function with different parameters.
+    ///
+    /// For reference, on Linux with `musl` or `glibc`, the `syslog` function
+    /// communicates with a daemon listening on the `/dev/log` Unix stream socket
+    /// using the RFC 3164 protocol. This daemon is typically `systemd-journald`,
+    /// `syslogd`, `rsyslogd`, or `syslog-ng`. FreeBSD uses the `syslogd` daemon
+    /// listening on the `/var/run/log` Unix datagram socket. Older macOS versions
+    /// used the `/var/run/syslog` Unix stream socket, while newer versions (10.x+)
+    /// forward logs to the OSLog framework (a.k.a. unified logging system) and lack
+    /// a `syslogd`-compatible daemon that listens on a socket. Other systems and
+    /// standard C libraries may have different implementations of such a function.
+    ///
+    /// [`syslog` C function]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/syslog.html
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg(unix)]
+    pub fn syslog_call() -> Self {
+        SyslogConnection(Connection::SyslogCall)
     }
 
     /// Returns a `Syslog` that sends the log lines via TCP to the specified address.


### PR DESCRIPTION
The `SyslogWriter` in `flexi_logger` is indeed quite flexible regarding syslog connection strategies. However, it's missing a particularly useful option for portable logging to whatever implementation-defined `syslog` daemon is available across Unix systems: just submitting log records to the [POSIX-standard `syslog` C function](https://pubs.opengroup.org/onlinepubs/9799919799/functions/syslog.html), which abstracts away the underlying IPC mechanisms used to communicate with the system log daemon.

In other contexts, the absence of this abstraction has already caused [developers to struggle with macOS updates that suddenly broke logging to the `/var/run/syslog` Unix socket](https://github.com/python/cpython/issues/91070). And more broadly, the lack of a de facto standard socket address for syslog daemons makes it difficult to write portable Unix software; all of Linux, macOS, FreeBSD, and Solaris, which I've studied in more depth, conventionally use different paths.

This pull request introduces a new `SyslogCall` connection type to `SyslogWriter`, which simply forwards log records to the `syslog` C function using the safe bindings provided by the `nix` crate.

In addition, I've made a few related, smaller improvements:

- Fixed an issue where `SyslogWriter` did not respect the configured `max_log_level`.
- Removed the dependency on the `hostname` crate for Unix targets, as `nix` already offers the same functionality. This also helps avoid dependency resolution conflicts that may arise from multiple crates pulling in different versions of `libc`.
- Eliminated the unused dependency on `libc`.
- The hostname is now only fetched if it's actually used by the requested header line format, which helps reducing the total amount of system calls in common cases.
- Replaced conditional compilation predicates of `target_family = "unix"` with `unix`, which is equivalent but shorter.

These changes have been tested and verified to integrate correctly with the local system log daemon on two different machines, one running Linux and the other macOS Sonoma.