### PR TITLE
feat: log file cleanup by day limit with `Cleanup::KeepLogDays(usize)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ async = ["dep:crossbeam-channel", "dep:crossbeam-queue"]
 buffer_writer = []
 colors = ["dep:nu-ansi-term"]
 compress = ["dep:flate2"]
+days = ["dep:filetime"]
 dont_minimize_extra_stacks = []
 json = ["dep:serde_json", "dep:serde", "dep:serde_derive"]
 kv = ["log/kv_serde"]
@@ -59,6 +60,7 @@ tracing = { version = "0.1.36", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [
     "env-filter",
 ] }
+filetime = { version = "0.2.26", optional = true }
 
 [target.'cfg(not(unix))'.dependencies]
 hostname = { version = "0.4", optional = true }

--- a/src/parameters/cleanup.rs
+++ b/src/parameters/cleanup.rs
@@ -19,6 +19,12 @@ pub enum Cleanup {
     /// The specified number of rotated log files are kept.
     /// Older files are deleted, if necessary.
     KeepLogFiles(usize),
+    
+    /// The specified number of days log files are kept.
+    /// Older files are deleted, if necessary.
+    #[cfg(feature = "days")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "days")))]
+    KeepLogDays(usize),
 
     /// The specified number of rotated log files are compressed and kept.
     /// Older files are deleted, if necessary.

--- a/tests/test_cleanup_by_day_limit.rs
+++ b/tests/test_cleanup_by_day_limit.rs
@@ -1,0 +1,68 @@
+mod test_utils;
+
+#[cfg(feature = "days")]
+#[test]
+fn test_cleanup_by_day_limit() {
+    use filetime::{set_file_mtime, FileTime};
+    use flexi_logger::{Cleanup, Criterion, Duplicate, FileSpec, Logger, Naming};
+    use log::*;
+    use std::{fs, thread, time::Duration};
+
+    let directory = test_utils::dir();
+
+    Logger::try_with_str("info")
+        .unwrap()
+        .log_to_file(FileSpec::default().directory(&directory))
+        .duplicate_to_stderr(Duplicate::Info)
+        .rotate(
+            Criterion::Size(100),
+            Naming::Numbers,
+            Cleanup::KeepLogDays(1),
+        )
+        .start()
+        .unwrap();
+
+    for i in 0..5 {
+        info!("log line {i}");
+    }
+
+    let mut log_files: Vec<_> = fs::read_dir(&directory)
+        .unwrap()
+        .filter_map(|e| {
+            let p = e.unwrap().path();
+            if p.extension().map(|ext| ext == "log").unwrap_or(false) {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .collect();
+    let two_days_ago = std::time::SystemTime::now() - Duration::from_secs(2 * 24 * 3600);
+    let ft = FileTime::from_system_time(two_days_ago);
+    for file in &log_files {
+        if file.exists() {
+            let _ = set_file_mtime(file, ft);
+        }
+    }
+    log_files.sort();
+    let old_file = log_files.first().expect("should have log files");
+    let two_days_ago = std::time::SystemTime::now() - Duration::from_secs(2 * 24 * 3600);
+    let ft = FileTime::from_system_time(two_days_ago);
+    if old_file.exists() {
+        set_file_mtime(old_file, ft).unwrap();
+    }
+
+    for i in 0..3 {
+        info!("trigger cleanup {i}");
+        thread::sleep(Duration::from_millis(120));
+    }
+
+    let start = std::time::Instant::now();
+    while old_file.exists() && start.elapsed().as_secs() < 2 {
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !old_file.exists(),
+        "old file should be deleted by day_limit cleanup"
+    );
+}


### PR DESCRIPTION
### New Feature: Log File Cleanup by Day Limit (`days` feature)

This PR introduces a new feature that allows automatic cleanup of log files based on their age in days.

#### Highlights

- **New `days` Feature:**  
  When enabled, log files older than a configurable number of days are automatically deleted.
- **Implementation Details:**  
  - Uses the `filetime` crate to reliably read file modification times.
  - The cleanup logic checks each log file’s last modification time and removes files exceeding the configured day limit.
  - The day-based cleanup is integrated with existing log and compression limits, ensuring compatibility with other cleanup strategies.
  - Error handling is robust: files with invalid modification times are skipped, and file deletion errors are logged but do not interrupt the cleanup process.
- **Testing:**  
  - Includes a dedicated test (`test_cleanup_by_day_limit`) that verifies old log files are properly deleted according to the day limit.

#### Affected Files

- list_and_cleanup.rs: Implements the core day-based cleanup logic.
- Cargo.toml: Adds the `days` feature and the `filetime` dependency.
- test_cleanup_by_day_limit.rs: Adds/updates tests for this feature.

#### Compatibility

- The feature is opt-in and does not affect default behavior.
- It is only active when the `days` feature is enabled.
