### PR TITLE
Update temp-dir dev-dependency from 0.1 to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,6 @@ flate2 = "1.0"
 glob = "0.3"
 serde_derive = "1.0"
 version-sync = "0.9"
-temp-dir = "0.1"
+temp-dir = "0.2"
 tracing = "0.1.36"
 #env_logger = '*' # optionally needed for the performance example


### PR DESCRIPTION
I confirmed that `cargo test` still passes.